### PR TITLE
Tooling: pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+exclude: "node_modules|migrations|.venv|.direnv|tests/dev/|tests/fixtures/"
+fail_fast: false
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        args: ["--select=E9,F63,F7,F82"]
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: quarterly

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires=">=3.6,<4",
     install_requires=["pywin32>=300; sys_platform == 'win32'"],
     extras_require={
-        "dev": ["flake8<4.1", "pytest<7.2"],
+        "dev": ["black==22.*", "flake8<4.1", "pre-commit<2.20", "pytest<7.2"],
     },
     license=about["__license__"],
     zip_safe=True,


### PR DESCRIPTION
Add pre-commit configuration to auto applying black, flake8, isort and basics controls before to commit.

The configuration file includes settings for the CI platform https://pre-commit.ci/ (free, @jiri-otoupal if you want to subscribe).