### PR TITLE
Fix for args & target improperly being split

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/pycrosskit/constants.py
+++ b/pycrosskit/constants.py
@@ -1,4 +1,8 @@
 from collections import namedtuple
 
-UserFolders = namedtuple("UserFolders", ("home", "desktop", "startmenu"))
-ParseArgumentsPattern = r'"?([^.]*[.][^ "]*)"? ?(.*)'  # Splits executable and arguments using the space immediately after file extension as seperator
+user_folders = namedtuple("UserFolders", ("home", "desktop", "startmenu"))
+"""
+Regex Pattern Splits executable and arguments using the space
+immediately after file extension as seperator
+"""
+parse_arguments_pattern = r'"?([^.]*[.][^ "]*)"? ?(.*)'

--- a/pycrosskit/constants.py
+++ b/pycrosskit/constants.py
@@ -1,3 +1,4 @@
 from collections import namedtuple
 
 UserFolders = namedtuple("UserFolders", ("home", "desktop", "startmenu"))
+ParseArgumentsPattern = r'"?([^.]*[.][^ "]*)"? ?(.*)'  # Splits executable and arguments using the space immediately after file extension as seperator

--- a/pycrosskit/shortcut_platforms/linux.py
+++ b/pycrosskit/shortcut_platforms/linux.py
@@ -7,7 +7,7 @@ import stat
 from pathlib import Path
 from typing import Tuple
 
-from pycrosskit.constants import UserFolders
+from pycrosskit.constants import user_folders
 from pycrosskit.shortcuts import Shortcut
 
 scut_ext = ".desktop"
@@ -81,16 +81,16 @@ def get_startmenu() -> str:
     return os.path.join(homedir, ".local", "share", "applications")
 
 
-def get_folders() -> UserFolders:
+def get_folders() -> user_folders:
     """Get user folders.
 
     :return UserFolders: user folders named tuple
     """
-    return UserFolders(get_homedir(), get_desktop(), get_startmenu())
+    return user_folders(get_homedir(), get_desktop(), get_startmenu())
 
 
 def create_shortcut(
-        shortcut_instance: Shortcut, desktop: bool = False, startmenu: bool = False
+    shortcut_instance: Shortcut, desktop: bool = False, startmenu: bool = False
 ):
     """Creates shortcut on the system.
 
@@ -115,8 +115,8 @@ def create_shortcut(
             name=shortcut_instance.shortcut_name,
             desc=shortcut_instance.description,
             exe=f"bash -c "
-                f"'cd {shortcut_instance.work_path}"
-                f" && {shortcut_instance.exec_path}'",
+            f"'cd {shortcut_instance.work_path}"
+            f" && {shortcut_instance.exec_path}'",
             icon=shortcut_instance.icon_path,
             args=shortcut_instance.arguments,
         )

--- a/pycrosskit/shortcut_platforms/windows.py
+++ b/pycrosskit/shortcut_platforms/windows.py
@@ -10,7 +10,7 @@ from typing import Tuple
 import win32com.client
 from win32comext.shell import shell, shellcon
 
-from pycrosskit.constants import UserFolders
+from pycrosskit.constants import user_folders
 from pycrosskit.shortcuts import Shortcut
 
 scut_ext = ".lnk"
@@ -58,12 +58,12 @@ def get_startmenu() -> str:
     return shell.SHGetFolderPath(0, shellcon.CSIDL_PROGRAMS, None, 0)
 
 
-def get_folders() -> UserFolders:
+def get_folders() -> user_folders:
     """Get user folders.
 
     :return UserFolders: user folders named tuple
     """
-    return UserFolders(get_homedir(), get_desktop(), get_startmenu())
+    return user_folders(get_homedir(), get_desktop(), get_startmenu())
 
 
 def create_shortcut(

--- a/pycrosskit/shortcuts.py
+++ b/pycrosskit/shortcuts.py
@@ -47,7 +47,7 @@ class Shortcut:
 
         # create shortcut
         self.desktop_path, self.startmenu_path = create_shortcut(
-            self, start_menu, desktop
+            self, startmenu=start_menu, desktop=desktop
         )
 
     @staticmethod
@@ -68,4 +68,4 @@ class Shortcut:
         else:
             from pycrosskit.shortcut_platforms.linux import delete_shortcut
 
-        return delete_shortcut(shortcut_name, desktop, start_menu)
+        return delete_shortcut(shortcut_name, desktop=desktop, startmenu=start_menu)

--- a/pycrosskit/shortcuts.py
+++ b/pycrosskit/shortcuts.py
@@ -5,7 +5,7 @@ import os
 import re
 from typing import Tuple
 
-from pycrosskit.constants import ParseArgumentsPattern
+from pycrosskit.constants import parse_arguments_pattern
 
 # conditional
 
@@ -33,7 +33,7 @@ class Shortcut:
 
         """
         self.exec_path, self.arguments = re.match(
-            ParseArgumentsPattern, str(exec_path)
+            parse_arguments_pattern, str(exec_path)
         ).group(1, 2)
         self.shortcut_name = shortcut_name
         self.description = description

--- a/pycrosskit/shortcuts.py
+++ b/pycrosskit/shortcuts.py
@@ -2,36 +2,39 @@
 
 # standard
 import os
+import re
 from typing import Tuple
 
+from pycrosskit.constants import ParseArgumentsPattern
 
 # conditional
 
 
 class Shortcut:
     def __init__(
-            self,
-            shortcut_name: str,
-            exec_path: str,
-            description: str = "",
-            icon_path: str = "",
-            desktop: bool = False,
-            start_menu: bool = False,
-            work_dir: str = None,
+        self,
+        shortcut_name: str,
+        exec_path: str,
+        description: str = "",
+        icon_path: str = "",
+        desktop: bool = False,
+        start_menu: bool = False,
+        work_dir: str = None,
     ):
         """Initialize a shortcut object.
 
         :param str shortcut_name: Name of Shortcut that will be created
-        :param str exec_path: Path to Executable
+        :param str exec_path: Path to Executable follow by arguments to be passed
         :param str description: Custom Description, defaults to ""
         :param str icon_path: Path to icon .ico, defaults to ""
         :param bool desktop: True to Generate Desktop Shortcut, defaults to False
         :param bool start_menu: True to Generate Start Menu Shortcut, defaults to False
         :param str work_dir: _description_, defaults to None
-        
+
         """
-        self.exec_path = str(exec_path)
-        self.arguments = "".join(exec_path.split(" ")[1:])
+        self.exec_path, self.arguments = re.match(
+            ParseArgumentsPattern, str(exec_path)
+        ).group(1, 2)
         self.shortcut_name = shortcut_name
         self.description = description
         self.icon_path = str(icon_path)
@@ -49,7 +52,7 @@ class Shortcut:
 
     @staticmethod
     def delete(
-            shortcut_name: str, desktop: bool = False, start_menu: bool = False
+        shortcut_name: str, desktop: bool = False, start_menu: bool = False
     ) -> Tuple[str, str]:
         """Remove existing Shortcut from the system.
 

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -6,38 +6,53 @@ from pycrosskit.shortcuts import Shortcut
 
 class Test_Shortcuts(unittest.TestCase):
     def test_exec_args_splitting(self):
+        """Tests to make sure the target file
+        and arguments are split correctly"""
+
         sh = Shortcut(
             "SplitTest",
-            "file name with spaces.py --and --args 'with options.txt'",
+            "\"file name with spaces.py\" --and --args 'with options.txt'",
             desktop=True,
         )
         self.assertEqual("file name with spaces.py", sh.exec_path)
         self.assertEqual("--and --args 'with options.txt'", sh.arguments)
 
-        desktop, _ = Shortcut.delete("SplitTest", desktop=True)
+        Shortcut.delete("SplitTest", desktop=True)
 
     def test_create_desktop(self):
+        """Test Creation of shortcut with only desktop option"""
+
         sh = Shortcut("Test", "__init__.py", desktop=True)
         self.assertEqual(True, os.path.exists(sh.desktop_path))
 
     def test_delete_desktop(self):
+        """Test Deletion of shortcut with only desktop option"""
+
         desktop, _ = Shortcut.delete("Test", desktop=True)
         self.assertEqual(True, not os.path.exists(desktop))
 
     def test_create_startmenu(self):
+        """Test Creation of shortcut with only startmenu option"""
+
         sh = Shortcut("Test", "__init__.py", start_menu=True)
         self.assertEqual(True, os.path.exists(sh.startmenu_path))
 
     def test_delete_startmenu(self):
+        """Test Deletion of shortcut with only startmenu option"""
+
         _, startmenu = Shortcut.delete("Test", start_menu=True)
         self.assertEqual(True, not os.path.exists(startmenu))
 
     def test_create_both(self):
+        """Test Creation of shortcut with both options"""
+
         sh = Shortcut("Test", "__init__.py", desktop=True, start_menu=True)
         self.assertEqual(True, os.path.exists(sh.desktop_path))
         self.assertEqual(True, os.path.exists(sh.startmenu_path))
 
     def test_delete_both(self):
+        """Test Deletion of shortcut with both options"""
+
         desktop, start_menu = Shortcut.delete("Test", desktop=True, start_menu=True)
         self.assertEqual(True, not os.path.exists(desktop))
         self.assertEqual(True, not os.path.exists(start_menu))

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -8,7 +8,8 @@ class Test_Shortcuts(unittest.TestCase):
     def test_exec_args_splitting(self):
         """
         Tests to make sure the target file
-        and arguments are split correctly"""
+        and arguments are split correctly
+        """
         sh = Shortcut(
             "SplitTest",
             "\"file name with spaces.py\" --and --args 'with options.txt'",

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -5,6 +5,17 @@ from pycrosskit.shortcuts import Shortcut
 
 
 class Test_Shortcuts(unittest.TestCase):
+    def test_exec_args_splitting(self):
+        sh = Shortcut(
+            "SplitTest",
+            "file name with spaces.py --and --args 'with options.txt'",
+            desktop=True,
+        )
+        self.assertEqual("file name with spaces.py", sh.exec_path)
+        self.assertEqual("--and --args 'with options.txt'", sh.arguments)
+
+        desktop, _ = Shortcut.delete("SplitTest", desktop=True)
+
     def test_create_desktop(self):
         sh = Shortcut("Test", "__init__.py", desktop=True)
         self.assertEqual(True, os.path.exists(sh.desktop_path))

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -6,9 +6,9 @@ from pycrosskit.shortcuts import Shortcut
 
 class Test_Shortcuts(unittest.TestCase):
     def test_exec_args_splitting(self):
-        """Tests to make sure the target file
+        """
+        Tests to make sure the target file
         and arguments are split correctly"""
-
         sh = Shortcut(
             "SplitTest",
             "\"file name with spaces.py\" --and --args 'with options.txt'",
@@ -21,38 +21,32 @@ class Test_Shortcuts(unittest.TestCase):
 
     def test_create_desktop(self):
         """Test Creation of shortcut with only desktop option"""
-
         sh = Shortcut("Test", "__init__.py", desktop=True)
         self.assertEqual(True, os.path.exists(sh.desktop_path))
 
     def test_delete_desktop(self):
         """Test Deletion of shortcut with only desktop option"""
-
         desktop, _ = Shortcut.delete("Test", desktop=True)
         self.assertEqual(True, not os.path.exists(desktop))
 
     def test_create_startmenu(self):
         """Test Creation of shortcut with only startmenu option"""
-
         sh = Shortcut("Test", "__init__.py", start_menu=True)
         self.assertEqual(True, os.path.exists(sh.startmenu_path))
 
     def test_delete_startmenu(self):
         """Test Deletion of shortcut with only startmenu option"""
-
         _, startmenu = Shortcut.delete("Test", start_menu=True)
         self.assertEqual(True, not os.path.exists(startmenu))
 
     def test_create_both(self):
         """Test Creation of shortcut with both options"""
-
         sh = Shortcut("Test", "__init__.py", desktop=True, start_menu=True)
         self.assertEqual(True, os.path.exists(sh.desktop_path))
         self.assertEqual(True, os.path.exists(sh.startmenu_path))
 
     def test_delete_both(self):
         """Test Deletion of shortcut with both options"""
-
         desktop, start_menu = Shortcut.delete("Test", desktop=True, start_menu=True)
         self.assertEqual(True, not os.path.exists(desktop))
         self.assertEqual(True, not os.path.exists(start_menu))


### PR DESCRIPTION
fixes #53, fixes #54 

Contains three changes:

1. Uses regex to fix the #53 as well as a test to check for the same

2. Bumped up isort version in pre-commit-config.yaml, I dont know a lot on the matter but apparently they had a bug on their end that would cause pre-commit hooks to fail and this is the closest version with a fix, [reference ](https://github.com/home-assistant/core/issues/86892)

3. Changed the way the parameters are passed in pycrosskit.Shortcut to fix #54 

:)