### PR TITLE
except KeyError preferred than except Exception

### DIFF
--- a/tests/test_env_vars_linux.py
+++ b/tests/test_env_vars_linux.py
@@ -29,10 +29,8 @@ class TestEnvVars(unittest.TestCase):
 
         try:
             SysEnv().get("test")
-            self.fail()
-        except Exception:
+        except KeyError:
             pass
-
 
 if __name__ == "__main__":
     if os.name != "nt":


### PR DESCRIPTION
If the except block catches a very general exception, it is likely to catch any unrelated errors too. Try to be more explicit about which exception(s) you're trying to catch.